### PR TITLE
Add DevContainer for Java 17 and Node.js

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,10 @@
 # Use the base image for Java 17
 FROM mcr.microsoft.com/devcontainers/java:17
 
-# Install Maven
-RUN apt-get update && apt-get install -y maven
+# Install Maven and Node.js
+RUN apt-get update && apt-get install -y maven curl \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs
 
 # Ensure the vscode user exists (skip group creation if it exists)
 RUN id -u vscode &>/dev/null || useradd --uid 1000 --gid 1000 -m vscode \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# Use the base image for Java 17
+FROM mcr.microsoft.com/devcontainers/java:17
+
+# Install Maven
+RUN apt-get update && apt-get install -y maven
+
+# Ensure the vscode user exists (skip group creation if it exists)
+RUN id -u vscode &>/dev/null || useradd --uid 1000 --gid 1000 -m vscode \
+    && echo "vscode ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# Set up work directory
+WORKDIR /workspace
+
+# Switch to vscode user
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,9 @@
                 "dbaeumer.vscode-eslint",           // ESLint extension
                 "eamodio.gitlens",                  // GitLens extension for Git support
                 "github.github-vscode-theme",       // GitHub Theme
-                "dsznajder.es7-react-js-snippets"  // React snippets
+                "dsznajder.es7-react-js-snippets",  // React snippets
+                "hbenl.vscode-test-explorer",       // Test Explorer UI
+                "ms-azuretools.vscode-docker"       // Docker extension
             ],
             "settings": {
                 "java.jdt.ls.java.home": "/usr/local/openjdk-17",
@@ -27,6 +29,7 @@
                         "default": true
                     }
                 ],
+                "remote.containers.defaultExtensions": [],
                 "workbench.colorTheme": "GitHub Dark" // GitHub theme
             }
         }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
-    "name": "Java 17 Dev Container",
+    "name": "Full Stack Dev Container",
     "build": {
-        "dockerfile": "Dockerfile"
+        "dockerfile": "Dockerfile",
+        "context": "."
     },
     "customizations": {
         "vscode": {
@@ -10,20 +11,28 @@
                 "vscjava.vscode-maven",
                 "vscjava.vscode-spring-initializr",
                 "vscjava.vscode-java-debug",
-                "vscjava.vscode-java-test"
-            ]
+                "vscjava.vscode-java-test",
+                "esbenp.prettier-vscode",           // Prettier extension
+                "dbaeumer.vscode-eslint",           // ESLint extension
+                "eamodio.gitlens",                  // GitLens extension for Git support
+                "github.github-vscode-theme",       // GitHub Theme
+                "dsznajder.es7-react-js-snippets"  // React snippets
+            ],
+            "settings": {
+                "java.jdt.ls.java.home": "/usr/local/openjdk-17",
+                "java.configuration.runtimes": [
+                    {
+                        "name": "JavaSE-17",
+                        "path": "/usr/local/openjdk-17",
+                        "default": true
+                    }
+                ],
+                "workbench.colorTheme": "GitHub Dark" // GitHub theme
+            }
         }
     },
-    "settings": {
-        "java.home": "/usr/local/openjdk-17",
-        "java.configuration.runtimes": [
-            {
-                "name": "JavaSE-17",
-                "path": "/usr/local/openjdk-17",
-                "default": true
-            }
-        ]
-    },
-    "postCreateCommand": "cd backend && mvn clean install",
-    "remoteUser": "vscode"
+    "postCreateCommand": "cd backend && mvn clean install && cd ../frontend && npm install",
+    "remoteUser": "vscode",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+    "workspaceFolder": "/workspace"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+    "name": "Java 17 Dev Container",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vscjava.vscode-java-pack",
+                "vscjava.vscode-maven",
+                "vscjava.vscode-spring-initializr",
+                "vscjava.vscode-java-debug",
+                "vscjava.vscode-java-test"
+            ]
+        }
+    },
+    "settings": {
+        "java.home": "/usr/local/openjdk-17",
+        "java.configuration.runtimes": [
+            {
+                "name": "JavaSE-17",
+                "path": "/usr/local/openjdk-17",
+                "default": true
+            }
+        ]
+    },
+    "postCreateCommand": "cd backend && mvn clean install",
+    "remoteUser": "vscode"
+}

--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}


### PR DESCRIPTION
This pull request adds a DevContainer configuration for Java 17 development. The Dockerfile installs Maven and Node.js, sets up the work directory, and switches to the vscode user. The `.devcontainer` file includes extensions for Java development, Prettier, ESLint, GitLens, GitHub Theme, and React snippets. It also sets the Java home path and runtime configuration. Additionally, the postCreateCommand installs dependencies for the backend and frontend. The unnecessary `.vscode` settings file is removed.